### PR TITLE
Remove default sshd banner

### DIFF
--- a/stage3/00-install-yunohost/00-run.sh
+++ b/stage3/00-install-yunohost/00-run.sh
@@ -47,8 +47,8 @@ echo "root:yunohost" | chpasswd
 EOF
 
 echo "Removing Raspbian sshd banner"
-rm /etc/ssh/sshd_config.d/rename_user.conf
-rm /usr/share/userconf-pi/sshd_banner
+rm -f /etc/ssh/sshd_config.d/rename_user.conf
+rm -f /usr/share/userconf-pi/sshd_banner
 
 install -m 755 files/check_yunohost_is_installed.sh "${ROOTFS_DIR}/etc/profile.d/"
 

--- a/stage3/00-install-yunohost/00-run.sh
+++ b/stage3/00-install-yunohost/00-run.sh
@@ -46,6 +46,10 @@ sed -i '/PermitRootLogin/c\PermitRootLogin yes' /etc/ssh/sshd_config
 echo "root:yunohost" | chpasswd
 EOF
 
+echo "Removing Raspbian sshd banner"
+rm /etc/ssh/sshd_config.d/rename_user.conf
+rm /usr/share/userconf-pi/sshd_banner
+
 install -m 755 files/check_yunohost_is_installed.sh "${ROOTFS_DIR}/etc/profile.d/"
 
 echo "Cleaning ..."


### PR DESCRIPTION
On Bullseye upon connecting with SSH before postinstall, users are shown the following message:

```
Please note that SSH may not work until a valid user has been set up.

See http://rptl.io/newuser for details.
```

Let's remove the banner to keep them on the right path.